### PR TITLE
Reject transferring update authority to executable programs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "create-metadata": "esrun src/token-metadata.ts create",
     "update-metadata": "esrun src/token-metadata.ts update",
-    "transfer-authority": "esrun src/transfer-updateAuthority.ts"
+    "transfer-authority": "esrun src/transfer-updateAuthority.ts",
+    "test": "vitest run"
   },
   "type": "module",
   "keywords": [],
@@ -20,5 +21,8 @@
     "@solana/web3.js": "^1.98.0",
     "dotenv": "^17.2.3",
     "esrun": "^3.2.26"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.2"
   }
 }

--- a/src/transfer-updateAuthority.ts
+++ b/src/transfer-updateAuthority.ts
@@ -1,20 +1,21 @@
 import "dotenv/config";
 import { getKeypairFromEnvironment, getExplorerLink } from "@solana-developers/helpers";
-import { clusterApiUrl, PublicKey } from "@solana/web3.js";
+import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
-import { 
+import {
   updateMetadataAccountV2,
   mplTokenMetadata,
   findMetadataPda
 } from "@metaplex-foundation/mpl-token-metadata";
-import { 
-  createSignerFromKeypair, 
-  signerIdentity, 
+import {
+  createSignerFromKeypair,
+  signerIdentity,
   publicKey as umiPublicKey,
   Umi
 } from "@metaplex-foundation/umi";
 import { base58 } from "@metaplex-foundation/umi/serializers";
 import * as readline from "readline";
+import { validateNotExecutable } from "./validate-authority.js";
 
 const user = getKeypairFromEnvironment("SOL_PRIVATE_KEY"); // MUST be the CURRENT update authority
 
@@ -30,6 +31,10 @@ const newUpdateAuthorityStr = process.argv[2];
 if (!newUpdateAuthorityStr) {
   throw new Error("Provide the new update authority pubkey as command line argument");
 }
+
+const connection = new Connection(clusterApiUrl(cluster));
+await validateNotExecutable(connection, newUpdateAuthorityStr);
+
 const newUpdateAuthority = umiPublicKey(newUpdateAuthorityStr);
 
 // Initialize Umi

--- a/src/validate-authority.test.ts
+++ b/src/validate-authority.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { Connection, clusterApiUrl } from "@solana/web3.js";
+import { validateNotExecutable } from "./validate-authority.js";
+
+const connection = new Connection(clusterApiUrl("devnet"));
+
+describe("validateNotExecutable", () => {
+  // NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm is an executable program on devnet
+  it("should reject an executable program account", async () => {
+    await expect(
+      validateNotExecutable(connection, "NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm")
+    ).rejects.toThrow("executable program account");
+  }, 30_000);
+
+  // 4iUtozoQLdJ2FV7vXe9q215ETSw1Mnt8WKP4NyqNgAxz is a non-executable account (PDA/wallet)
+  it("should allow a non-executable account", async () => {
+    await expect(
+      validateNotExecutable(connection, "4iUtozoQLdJ2FV7vXe9q215ETSw1Mnt8WKP4NyqNgAxz")
+    ).resolves.toBeUndefined();
+  }, 30_000);
+});

--- a/src/validate-authority.ts
+++ b/src/validate-authority.ts
@@ -1,0 +1,23 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+
+/**
+ * Validates that the given address is not an executable program account.
+ * Programs cannot sign transactions, so transferring update authority
+ * to a program would make the metadata permanently immutable.
+ * Throws if the address is an executable program.
+ */
+export async function validateNotExecutable(
+  connection: Connection,
+  address: string
+): Promise<void> {
+  const pubkey = new PublicKey(address);
+  const accountInfo = await connection.getAccountInfo(pubkey);
+  if (accountInfo?.executable) {
+    throw new Error(
+      `The provided address (${address}) is an executable program account. ` +
+      `Programs cannot sign transactions, so transferring update authority to a program ` +
+      `would make the metadata permanently immutable. ` +
+      `If you intend to use program-controlled authority, use a PDA derived from your program instead.`
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds on-chain validation that rejects transferring metadata update authority to executable program accounts, since programs cannot sign transactions and this would make metadata permanently immutable
- Extracts validation into reusable `validateNotExecutable()` function
- Adds vitest tests verifying the check against real devnet accounts

## Test plan
- [x] `npm test` passes — validates that `NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm` (executable) is rejected and `4iUtozoQLdJ2FV7vXe9q215ETSw1Mnt8WKP4NyqNgAxz` (non-executable) is allowed